### PR TITLE
fix problems with HopsWorksHelper when the user name is not a hopsworks name

### DIFF
--- a/src/main/java/io/hops/util/HopsWorksHelper.java
+++ b/src/main/java/io/hops/util/HopsWorksHelper.java
@@ -9,7 +9,12 @@ package io.hops.util;
 public class HopsWorksHelper {
 
   public static String getUserName(String totalName){
-    return totalName.split("__")[1];
+    String[] components = totalName.split("__");
+    if(components.length>=2){
+      return components[1];
+    }else{
+      return totalName;
+    }
   }
   
   public static String getProjectName(String totalName){


### PR DESCRIPTION
The HopsWorksHelper was geting out of bound when the incoming string is not a proper hopsworks name, which is the case in most of yarn tests. 
resolve #28 