### PR TITLE
Fix distributed mode recovery

### DIFF
--- a/src/main/java/io/hops/DalNdbEventStreaming.java
+++ b/src/main/java/io/hops/DalNdbEventStreaming.java
@@ -19,13 +19,12 @@ package io.hops;
  *
  * @author sri
  */
-
 public interface DalNdbEventStreaming {
 
-    public void startHopsNdbEvetAPISession();
+  public void startHopsNdbEvetAPISession(boolean isLeader);
 
-    public void closeHopsNdbEventAPISession();
+  public void closeHopsNdbEventAPISession();
 
-    public boolean isNativeCodeLoaded();
+  public boolean isNativeCodeLoaded();
 
 }

--- a/src/main/java/io/hops/StorageConnector.java
+++ b/src/main/java/io/hops/StorageConnector.java
@@ -38,7 +38,7 @@ public interface StorageConnector<T> {
   
   public boolean formatStorage(Class<? extends EntityDataAccess>... das)
       throws StorageException;
-  
+    
   public boolean isTransactionActive() throws StorageException;
 
   public void stopStorage() throws StorageException;
@@ -53,4 +53,6 @@ public interface StorageConnector<T> {
       throws StorageException;
   
   public void dropAndRecreateDB() throws StorageException;
+  
+  public void flush() throws StorageException;
 }

--- a/src/main/java/io/hops/metadata/yarn/entity/PendingEvent.java
+++ b/src/main/java/io/hops/metadata/yarn/entity/PendingEvent.java
@@ -17,37 +17,32 @@ package io.hops.metadata.yarn.entity;
 
 public class PendingEvent implements Comparable<PendingEvent> {
 
-  private final String rmnodeId;
+  private PendingEventID id;
   private final int type;
   private final int status;
-  //Used to order the events when retrieved by scheduler
-  private final int id;
 
+  
   public PendingEvent(String rmnodeId, int type, int status, int id) {
-    this.rmnodeId = rmnodeId;
     this.type = type;
     this.status = status;
-    this.id = id;
+    this.id = new PendingEventID(id, rmnodeId);
   }
 
+  public PendingEvent(PendingEvent pendingEvent) {
+    this.type = pendingEvent.getType();
+    this.status = pendingEvent.getStatus();
+    this.id = new PendingEventID(pendingEvent.getId().getEventId(),
+            pendingEvent.getId().getNodeId());
+  }
+  
   /**
    * Returns the globally unique id of the pending event.
    * <p/>
    *
    * @return
    */
-  public int getId() {
+  public PendingEventID getId() {
     return id;
-  }
-
-  /**
-   * Returns the RMNode id for which the event will be triggered.
-   * <p/>
-   *
-   * @return
-   */
-  public String getRmnodeId() {
-    return rmnodeId;
   }
 
   /**
@@ -72,14 +67,14 @@ public class PendingEvent implements Comparable<PendingEvent> {
 
   @Override
   public String toString() {
-    return "HopPendingEvent{" + "rmnodeId=" + rmnodeId + ", type=" + type +
-        ", status=" + status + ", id=" + id + '}';
+    return "HopPendingEvent{" + "rmnodeId=" + id.getNodeId() + ", type=" + type +
+        ", status=" + status + ", id=" + id.getEventId() + '}';
   }
 
   @Override
   public int hashCode() {
     int hash = 3;
-    hash = 53 * hash + this.id;
+    hash = 53 * hash + this.id.hashCode();
     return hash;
   }
 
@@ -92,7 +87,7 @@ public class PendingEvent implements Comparable<PendingEvent> {
       return false;
     }
     final PendingEvent other = (PendingEvent) obj;
-    if (this.id != other.id) {
+    if (!this.id.equals(other.id)) {
       return false;
     }
     return true;
@@ -101,10 +96,7 @@ public class PendingEvent implements Comparable<PendingEvent> {
 
   @Override
   public int compareTo(PendingEvent o) {
-    if (o == null) {
-      throw new NullPointerException("HopPendingEvent was null");
-    }
-    return this.id - o.getId();
+    return this.id.compareTo(o.getId());
   }
 
 }

--- a/src/main/java/io/hops/metadata/yarn/entity/PendingEventID.java
+++ b/src/main/java/io/hops/metadata/yarn/entity/PendingEventID.java
@@ -1,0 +1,50 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package io.hops.metadata.yarn.entity;
+
+public class PendingEventID implements Comparable<PendingEventID> {
+
+  private final Integer eventId;
+  private final String nodeId;
+
+  public PendingEventID(Integer eventId, String nodeId) {
+    this.eventId = eventId;
+    this.nodeId = nodeId;
+  }
+
+  public Integer getEventId() {
+    return eventId;
+  }
+
+  public String getNodeId() {
+    return nodeId;
+  }
+
+  @Override
+  public int compareTo(PendingEventID other) {
+    int first = eventId.compareTo(other.eventId);
+    if (first == 0) {
+      return nodeId.compareTo(other.nodeId);
+    }
+    return first;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o != null && getClass() != o.getClass()) {
+      PendingEventID other = (PendingEventID) o;
+      if (eventId.equals(other.eventId) && nodeId.equals(other.nodeId)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return nodeId.hashCode() + eventId;
+  }
+}

--- a/src/main/java/io/hops/metadata/yarn/entity/RMNodeComps.java
+++ b/src/main/java/io/hops/metadata/yarn/entity/RMNodeComps.java
@@ -34,6 +34,7 @@ public class RMNodeComps {
   private final List<FinishedApplications> hopFinishedApplications;
   private final List<ContainerStatus> hopContainersStatus;
   private Map<String, ContainerStatus> hopContainerStatusMap;
+  private final String rmNodeId;
 
   public RMNodeComps(RMNode hopRMNode, NextHeartbeat hopNextHeartbeat,
           Node hopNode,
@@ -43,7 +44,7 @@ public class RMNodeComps {
           List<UpdatedContainerInfo> hopUpdatedContainerInfo,
           List<ContainerId> hopContainerIdsToClean,
           List<FinishedApplications> hopFinishedApplications,
-          List<ContainerStatus> hopContainersStatus) {
+          List<ContainerStatus> hopContainersStatus, String rmNodeId) {
     this.hopRMNode = hopRMNode;
     this.hopNextHeartbeat = hopNextHeartbeat;
     this.hopNode = hopNode;
@@ -55,6 +56,7 @@ public class RMNodeComps {
     this.hopContainerIdsToClean = hopContainerIdsToClean;
     this.hopFinishedApplications = hopFinishedApplications;
     this.hopContainersStatus = hopContainersStatus;
+    this.rmNodeId = rmNodeId;
   }
 
 //  public RMNodeComps(RMNode hopRMNode, NextHeartbeat hopNextHeartbeat,
@@ -125,4 +127,7 @@ public class RMNodeComps {
     return hopNodeHBResponse;
   }
 
+  public String getRMNodeId(){
+    return rmNodeId;
+  }
 }


### PR DESCRIPTION
 Preparation to enable failover in distributed mode:

- identify pending events by their id and the node that emited them (the id is unique only per node)
- use the latest version of the streaming library

preparation for hopshadoop/hops#102