### PR TITLE
fix rpc too big bug

### DIFF
--- a/src/main/java/io/hops/metadata/yarn/TablesDef.java
+++ b/src/main/java/io/hops/metadata/yarn/TablesDef.java
@@ -357,6 +357,78 @@ public class TablesDef {
     public static final String USERID = "userid";
   }
 
+  public static interface HeartBeatRPCTableDef {
+
+    public static final String TABLE_NAME = "yarn_heartbeat_rpc";
+    public static final String RPCID = "rpcid";
+    public static final String NODEID = "nodeid";
+    public static final String RESPONSEID = "responseid";
+    public static final String NODE_HEALTH_STATUS = "node_health_status";
+    public static final String LAST_CONTAINER_TOKEN_KEY
+            = "last_container_token_key";
+    public static final String LAST_NM_KEY = "last_nm_key";
+  }
+
+  public static interface HeartBeatContainerStatusesTableDef {
+
+    public static final String TABLE_NAME = "yarn_heartbeat_container_statuses";
+    public static final String RPCID = "rpcid";
+    public static final String CONTAINERID = "containerid";
+    public static final String STATUS = "status";
+  }
+
+  public static interface HeartBeatKeepAliveApplications {
+
+    public static final String TABLE_NAME = "yarn_heartbeat_keepalive_app";
+    public static final String RPCID = "rpcid";
+    public static final String APPID = "appid";
+  }
+
+  public static interface AllocateRPC {
+
+    public static final String TABLE_NAME = "yarn_allocate_rpc";
+    public static final String RPCID = "rpcid";
+    public static final String PROGRESS = "progress";
+    public static final String RESPONSEID = "responseid";
+  }
+
+  public static interface AllocateRPCAsk {
+
+    public static final String TABLE_NAME = "yarn_allocate_rpc_ask";
+    public static final String RPCID = "rpcid";
+    public static final String REQUESTID = "requestid";
+    public static final String REQUEST = "request";
+  }
+
+  public static interface AllocateRPCBlackListAdd {
+
+    public static final String TABLE_NAME = "yarn_allocate_rpc_blacklist_add";
+    public static final String RPCID = "rpcid";
+    public static final String RESOURCE = "resource";
+  }
+
+  public static interface AllocateRPCBlackListRemove {
+
+    public static final String TABLE_NAME = "yarn_allocate_rpc_blacklist_remove";
+    public static final String RPCID = "rpcid";
+    public static final String RESOURCE = "resource";
+  }
+
+  public static interface AllocateRPCRelease {
+
+    public static final String TABLE_NAME = "yarn_allocate_rpc_release";
+    public static final String RPCID = "rpcid";
+    public static final String CONTAINERID = "containerid";
+  }
+
+  public static interface AllocateRPCResourceIncrease {
+
+    public static final String TABLE_NAME = "yarn_allocate_rpc_resource_increase";
+    public static final String RPCID = "rpcid";
+    public static final String REQUESTID = "containerid";
+    public static final String REQUEST = "request";
+  }
+
   /*
     Capacity
    */

--- a/src/main/java/io/hops/metadata/yarn/dal/rmstatestore/AllocateRPCDataAccess.java
+++ b/src/main/java/io/hops/metadata/yarn/dal/rmstatestore/AllocateRPCDataAccess.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 hops.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hops.metadata.yarn.dal.rmstatestore;
+
+import io.hops.exception.StorageException;
+import io.hops.metadata.common.EntityDataAccess;
+import java.util.Map;
+
+/**
+ *
+ * @author gautier
+ */
+public interface AllocateRPCDataAccess<T> extends EntityDataAccess {
+
+  void add(T toAdd) throws StorageException;
+
+  Map<Integer, T> getAll() throws StorageException;
+}

--- a/src/main/java/io/hops/metadata/yarn/dal/rmstatestore/HeartBeatRPCDataAccess.java
+++ b/src/main/java/io/hops/metadata/yarn/dal/rmstatestore/HeartBeatRPCDataAccess.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2015 hops.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hops.metadata.yarn.dal.rmstatestore;
+
+import io.hops.exception.StorageException;
+import io.hops.metadata.common.EntityDataAccess;
+import java.util.Map;
+
+/**
+ *
+ * @author gautier
+ */
+public interface HeartBeatRPCDataAccess<T> extends EntityDataAccess {
+
+  void add(T toAdd) throws StorageException;
+
+  Map<Integer, T> getAll() throws StorageException;
+}

--- a/src/main/java/io/hops/metadata/yarn/entity/appmasterrpc/AllocateRPC.java
+++ b/src/main/java/io/hops/metadata/yarn/entity/appmasterrpc/AllocateRPC.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2015 hops.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hops.metadata.yarn.entity.appmasterrpc;
+
+import java.util.List;
+import java.util.Map;
+
+public class AllocateRPC {
+
+  private final int rpcID;
+  private final int responseId;
+  private final float progress;
+  private final List<String> releaseList;
+  private final Map<String, byte[]> ask;
+  private final Map<String, byte[]> resourceIncreaseRequest;
+  private final List<String> blackListAddition;
+  private final List<String> blackListRemovals;
+
+  public AllocateRPC(int rpcID, int responseId, float progress,
+          List<String> releaseList, Map<String, byte[]> ask,
+          Map<String, byte[]> resourceIncreaseRequest,
+          List<String> blackListAddition, List<String> blackListRemovals) {
+    this.rpcID = rpcID;
+    this.responseId = responseId;
+    this.progress = progress;
+    this.releaseList = releaseList;
+    this.ask = ask;
+    this.resourceIncreaseRequest = resourceIncreaseRequest;
+    this.blackListAddition = blackListAddition;
+    this.blackListRemovals = blackListRemovals;
+  }
+
+  public int getRpcID() {
+    return rpcID;
+  }
+
+  public int getResponseId() {
+    return responseId;
+  }
+
+  public float getProgress() {
+    return progress;
+  }
+
+  public List<String> getReleaseList() {
+    return releaseList;
+  }
+
+  public Map<String, byte[]> getAsk() {
+    return ask;
+  }
+
+  public Map<String, byte[]> getResourceIncreaseRequest() {
+    return resourceIncreaseRequest;
+  }
+
+  public List<String> getBlackListAddition() {
+    return blackListAddition;
+  }
+
+  public List<String> getBlackListRemovals() {
+    return blackListRemovals;
+  }
+
+}

--- a/src/main/java/io/hops/metadata/yarn/entity/appmasterrpc/HeartBeatRPC.java
+++ b/src/main/java/io/hops/metadata/yarn/entity/appmasterrpc/HeartBeatRPC.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2015 hops.io.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.hops.metadata.yarn.entity.appmasterrpc;
+
+import java.util.List;
+import java.util.Map;
+
+public class HeartBeatRPC {
+
+  //NodeStatus
+
+  private final String nodeId;
+  private final int responseId;
+  private final Map<String, byte[]> containersStatuses;
+  private final List<String> keepAliveApplications;
+  private final byte[] nodeHealthStatus;
+
+  //keys
+  private final byte[] lastKnownContainerTokenMasterKey;
+  private final byte[] LastKnownNMTokenMasterKey;
+
+  //RPC
+  private final int rpcId;
+
+  public HeartBeatRPC(String nodeId, int responseId,
+          Map<String, byte[]> containersStatuses,
+          List<String> keepAliveApplications,
+          byte[] nodeHealthStatus, byte[] lastKnownContainerTokenMasterKey,
+          byte[] LastKnownNMTokenMasterKey, int rpcId) {
+    this.nodeId = nodeId;
+    this.responseId = responseId;
+    this.containersStatuses = containersStatuses;
+    this.keepAliveApplications = keepAliveApplications;
+    this.nodeHealthStatus = nodeHealthStatus;
+    this.lastKnownContainerTokenMasterKey = lastKnownContainerTokenMasterKey;
+    this.LastKnownNMTokenMasterKey = LastKnownNMTokenMasterKey;
+    this.rpcId = rpcId;
+  }
+
+  public String getNodeId() {
+    return nodeId;
+  }
+
+  public int getResponseId() {
+    return responseId;
+  }
+
+  public Map<String, byte[]> getContainersStatuses() {
+    return containersStatuses;
+  }
+
+  public List<String> getKeepAliveApplications() {
+    return keepAliveApplications;
+  }
+
+  public byte[] getNodeHealthStatus() {
+    return nodeHealthStatus;
+  }
+
+  public byte[] getLastKnownContainerTokenMasterKey() {
+    return lastKnownContainerTokenMasterKey;
+  }
+
+  public byte[] getLastKnownNMTokenMasterKey() {
+    return LastKnownNMTokenMasterKey;
+  }
+
+  public int getRpcId() {
+    return rpcId;
+  }
+
+}


### PR DESCRIPTION
Interfaces to commit to tables to break the Heartbeat and allocate rpcs in sub part when persisting them to the database to avoid problems of rpc too big to fit in a row of the database

preparation for hopshadoop/hops#109