### PR TITLE
correct capacity scheduler recovery

### DIFF
--- a/src/main/java/io/hops/metadata/yarn/TablesDef.java
+++ b/src/main/java/io/hops/metadata/yarn/TablesDef.java
@@ -652,4 +652,10 @@ public class TablesDef {
     public static final String CONTAINERID = "container_id";
     public static final String CHECKPOINT = "checkpoint";
   }
+  
+  public static interface CSLeafQueuesPendingAppsTableDef {
+    public static final String TABLE_NAME = "yarn_cs_leaf_queue_pending_apps";
+    public static final String APPATTEMPTID = "app_attempt_id";
+    public static final String PATH = "path";
+  }
 }

--- a/src/main/java/io/hops/metadata/yarn/dal/capacity/CSLeafQueuesPendingAppsDataAccess.java
+++ b/src/main/java/io/hops/metadata/yarn/dal/capacity/CSLeafQueuesPendingAppsDataAccess.java
@@ -1,0 +1,23 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package io.hops.metadata.yarn.dal.capacity;
+
+import io.hops.exception.StorageException;
+import io.hops.metadata.common.EntityDataAccess;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
+public interface CSLeafQueuesPendingAppsDataAccess<T extends Object> extends EntityDataAccess {
+
+  Map<String, Set<String>> getAll() throws StorageException, IOException;
+
+  public void addAll(Collection<T> clctn) throws StorageException;
+
+  public void removeAll(Collection<T> clctn) throws StorageException;
+}

--- a/src/main/java/io/hops/metadata/yarn/entity/capacity/LeafQueuePendingApp.java
+++ b/src/main/java/io/hops/metadata/yarn/entity/capacity/LeafQueuePendingApp.java
@@ -1,0 +1,32 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+
+package io.hops.metadata.yarn.entity.capacity;
+
+public class LeafQueuePendingApp {
+  private final String appAttemptId;
+  private final String queuePath;
+
+  public LeafQueuePendingApp(String appAttemptId, String queuePath) {
+    this.appAttemptId = appAttemptId;
+    this.queuePath = queuePath;
+  }
+  
+  public LeafQueuePendingApp(String appAttemptId) {
+    this.appAttemptId = appAttemptId;
+    this.queuePath = null;
+  }
+
+  public String getAppAttemptId() {
+    return appAttemptId;
+  }
+
+  public String getQueuePath() {
+    return queuePath;
+  }
+  
+  
+}


### PR DESCRIPTION
When recovering leafQueue the recover function was unsing appAttempt isPending to decide to put the application in the pending queue or in the active queue but appAttempt.isPending and the leafQueue pending queue are not linked, introducing a new mechanism to persist the pending queue in the database