### PR TITLE
[HOPS-458] SubTree operation on a large directory with millions of immediate children can kill the database.

### DIFF
--- a/src/main/java/io/hops/metadata/hdfs/dal/INodeDataAccess.java
+++ b/src/main/java/io/hops/metadata/hdfs/dal/INodeDataAccess.java
@@ -20,6 +20,7 @@ import io.hops.metadata.common.EntityDataAccess;
 import io.hops.metadata.hdfs.entity.INodeIdentifier;
 import io.hops.metadata.hdfs.entity.MetadataLogEntry;
 import io.hops.metadata.hdfs.entity.ProjectedINode;
+import io.hops.transaction.context.EntityContext;
 
 import java.util.Collection;
 import java.util.List;
@@ -32,10 +33,10 @@ public interface INodeDataAccess<T> extends EntityDataAccess {
 
   List<T> findInodesByParentIdAndPartitionIdPPIS(int parentId, int partitionId) throws StorageException;
 
-  List<ProjectedINode> findInodesForSubtreeOperationsWithWriteLockPPIS(int parentId, int partitionId)
+  List<ProjectedINode> findInodesPPISTx(int parentId, int partitionId, EntityContext.LockMode lock)
       throws StorageException;
 
-  List<ProjectedINode> findInodesForSubtreeOperationsWithWriteLockFTIS(int parentId)
+  List<ProjectedINode> findInodesFTISTx(int parentId, EntityContext.LockMode lock)
       throws StorageException;
 
   T findInodeByNameParentIdAndPartitionIdPK(String name, int parentId, int partitionId)
@@ -43,6 +44,9 @@ public interface INodeDataAccess<T> extends EntityDataAccess {
 
   List<T> getINodesPkBatched(String[] names, int[] parentIds, int[] partitionIds)
       throws StorageException;
+
+  List<T> lockInodesUsingPkBatchTx(String[] names, int[] parentIds, int[] partitionIds, EntityContext.LockMode lock)
+          throws StorageException;
 
   List<INodeIdentifier> getAllINodeFiles(long startId, long endId)
       throws StorageException;


### PR DESCRIPTION
[Hops-458] SubTree operation on a large directory with millions of immediate children can kill the database.

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-458

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Nay

* **Other information**:
None