### PR TITLE
[HOPS-842] Writing small files slow down when the disk tables in the database are full

### DIFF
--- a/src/main/java/io/hops/exception/OutOfDBExtentsException.java
+++ b/src/main/java/io/hops/exception/OutOfDBExtentsException.java
@@ -15,7 +15,7 @@
  */
 package io.hops.exception;
 
-public class OutOfDBExtentsException extends TransientStorageException{
+public class OutOfDBExtentsException extends StorageException{
   public OutOfDBExtentsException() {
   }
 


### PR DESCRIPTION
[HOPS-842] Writing small files slow down when the disk tables in the database are full

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/projects/HOPS/issues/HOPS-842

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the new behavior (if this is a feature change)?**
~

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
nope

* **Other information**:
nope