### PR TITLE
[HOPS-6] Availability Zone Awareness support for HopsFS

### DIFF
--- a/src/main/java/io/hops/metadata/election/TablesDef.java
+++ b/src/main/java/io/hops/metadata/election/TablesDef.java
@@ -22,6 +22,7 @@ public class TablesDef {
     public static final String RPC_ADDRESSES = "rpc_addresses";
     public static final String HTTP_ADDRESS = "http_address";
     public static final String PARTITION_VAL = "partition_val";
+    public static final String LOCATION_DOMAIN_ID = "location_domain_id";
   }
 
   public static interface HdfsLeaderTableDef extends LeDescriptorTableDef {

--- a/src/main/java/io/hops/metadata/election/entity/LeDescriptor.java
+++ b/src/main/java/io/hops/metadata/election/entity/LeDescriptor.java
@@ -40,12 +40,14 @@ public abstract class LeDescriptor
   }
 
   public static final int DEFAULT_PARTITION_VALUE = 0;
+  public static final byte DEFAULT_LOCATION_DOMAIN_ID = 0;
   private long id;
   private long counter;
   private String rpcAddresses;
   private String httpAddress;
   private final int partitionVal = 0;
-
+  private byte locationDomainId;
+  
   protected LeDescriptor() {
   }
 
@@ -54,16 +56,18 @@ public abstract class LeDescriptor
     this.counter = descriptor.counter;
     this.rpcAddresses = descriptor.rpcAddresses;
     this.httpAddress = descriptor.httpAddress;
+    this.locationDomainId = descriptor.locationDomainId;
   }
-
+  
   protected LeDescriptor(long id, long counter, String rpcAddresses,
-      String httpAddress) {
+      String httpAddress, byte locationDomainId) {
     this.id = id;
     this.counter = counter;
     this.rpcAddresses = rpcAddresses;
     this.httpAddress = httpAddress;
+    this.locationDomainId = locationDomainId;
   }
-
+  
   public long getId() {
     return id;
   }
@@ -99,7 +103,15 @@ public abstract class LeDescriptor
   public int getPartitionVal() {
     return partitionVal;
   }
-
+  
+  public byte getLocationDomainId() {
+    return locationDomainId;
+  }
+  
+  public void setLocationDomainId(byte locationDomainId) {
+    this.locationDomainId = locationDomainId;
+  }
+  
   @Override
   public int compareTo(LeDescriptor l) {
 
@@ -172,8 +184,8 @@ public abstract class LeDescriptor
     }
 
     public YarnLeDescriptor(long id, long counter, String hostName,
-        String httpAddress) {
-      super(id, counter, hostName, httpAddress);
+        String httpAddress, byte locationDomainId) {
+      super(id, counter, hostName, httpAddress, locationDomainId);
     }
   }
 
@@ -203,8 +215,8 @@ public abstract class LeDescriptor
     }
 
     public HdfsLeDescriptor(long id, long counter, String rpcAddresses,
-        String httpAddress) {
-      super(id, counter,  rpcAddresses, httpAddress);
+        String httpAddress, byte locationDomainId) {
+      super(id, counter,  rpcAddresses, httpAddress, locationDomainId);
     }
   }
 

--- a/src/main/java/io/hops/metadata/election/entity/LeDescriptorFactory.java
+++ b/src/main/java/io/hops/metadata/election/entity/LeDescriptorFactory.java
@@ -29,6 +29,6 @@ public abstract class LeDescriptorFactory {
   public abstract LeDescriptor cloneDescriptor(LeDescriptor desc);
   
   public abstract LeDescriptor getNewDescriptor(long id, long counter,
-      String hostName, String httpAddress);
+      String hostName, String httpAddress, byte locationDomainId);
   
 }


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-6

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature

* **What is the new behavior (if this is a feature change)?**
Admins can assign a namenode to a specific availability zone using a new configuration parameter in hdfs-site. Users can also assign their clients to a specific availability zone to enforce using a namenode from the same availability zone.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: