### PR TITLE
[HOPS-1152] Allow disabling Users/Groups Cache on the NN side

### DIFF
--- a/src/main/java/io/hops/exception/UniqueKeyConstraintViolationException.java
+++ b/src/main/java/io/hops/exception/UniqueKeyConstraintViolationException.java
@@ -15,7 +15,7 @@
  */
 package io.hops.exception;
 
-public class UniqueKeyConstraintViolationException extends TransientStorageException{
+public class UniqueKeyConstraintViolationException extends StorageException{
   public UniqueKeyConstraintViolationException() {
   }
 


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/projects/HOPS/issues/HOPS-1152?filter=allopenissues

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**:
hops layer also changed
https://github.com/hopshadoop/hops/pull/639
https://github.com/hopshadoop/hops-metadata-dal/pull/155
https://github.com/hopshadoop/hops-metadata-dal-impl-ndb/pull/193
