### PR TITLE
[HOPS-1343] Recover inode if reset subtree lock fails

### DIFF
--- a/src/main/java/io/hops/metadata/hdfs/TablesDef.java
+++ b/src/main/java/io/hops/metadata/hdfs/TablesDef.java
@@ -338,6 +338,10 @@ public class TablesDef {
     String NAME_NODE_ID = "namenode_id";
     String OP_NAME = "op_name";
     String PARTITION_ID = "partition_id";
+    String START_TIME = "start_time";
+    String ASYNC_LOCK_RECOVERY_TIME = "async_lock_recovery_time";
+    String USER = "user";
+    String INODE_ID = "inode_id";
   }
 
   public interface HashBucketsTableDef {

--- a/src/main/java/io/hops/metadata/hdfs/dal/OngoingSubTreeOpsDataAccess.java
+++ b/src/main/java/io/hops/metadata/hdfs/dal/OngoingSubTreeOpsDataAccess.java
@@ -22,9 +22,13 @@ import java.util.Collection;
 
 public interface OngoingSubTreeOpsDataAccess<T> extends EntityDataAccess {
 
+  T findByPath(String path) throws StorageException;
+
   Collection<T> findByPathsByPrefix(String prefix) throws StorageException;
 
   Collection<T> allOpsByNN(long nnID) throws StorageException;
+
+  Collection<T> allOpsToRecoverAsync() throws StorageException;
 
   //only for testing
   Collection<T> allOps() throws StorageException;

--- a/src/main/java/io/hops/metadata/hdfs/entity/SubTreeOperation.java
+++ b/src/main/java/io/hops/metadata/hdfs/entity/SubTreeOperation.java
@@ -52,17 +52,35 @@ public class SubTreeOperation implements Comparable<SubTreeOperation> {
   private long nameNodeId;
   private String path;
   private Type opType;
+  private long asyncLockRecoveryTime = 0;  // contains the time when async was enabled. 0 = disabled
+  private long startTime;
+  private String user;
+  private long inodeID;
 
   public SubTreeOperation(String path){
     this.path = path;
     this.nameNodeId = -1;
-    this.opType = opType.NA; 
+    this.opType = opType.NA;
+    this.asyncLockRecoveryTime = 0;
+    this.startTime = System.currentTimeMillis();
+    this.user = "";
+    this.inodeID = 0;
   }
-          
-  public SubTreeOperation(String path, long nameNodeId, Type opType) {
+
+  public SubTreeOperation(String path, long inodeID,  long nameNodeId, Type opType, long startTime,
+                          String user) {
+    this(path, inodeID, nameNodeId, opType, startTime, user, 0);
+  }
+
+  public SubTreeOperation(String path, long inodeID, long nameNodeId, Type opType,
+                          long startTime, String user, long asyncLockRecovery) {
     this.path = path;
     this.nameNodeId = nameNodeId;
-    this.opType = opType; 
+    this.opType = opType;
+    this.startTime = startTime;
+    this.user = user;
+    this.asyncLockRecoveryTime = asyncLockRecovery;
+    this.inodeID = inodeID;
   }
 
   /**
@@ -73,7 +91,7 @@ public class SubTreeOperation implements Comparable<SubTreeOperation> {
   }
 
   /**
-   * @param name node id
+   * @param nameNodeId namenode id
    *     set the name node id
    */
   public void setHolderId(long nameNodeId) {
@@ -110,7 +128,66 @@ public class SubTreeOperation implements Comparable<SubTreeOperation> {
   public void setOpType(Type opType) {
     this.opType = opType;
   }
-  
+
+  /**
+   * get async recovery start time. 0 = disabled
+   */
+  public long getAsyncLockRecoveryTime() {
+    return asyncLockRecoveryTime;
+  }
+
+  /**
+   * Enable async recovery
+   * @param asyncLockRecoveryTime
+   */
+  public void setAsyncLockRecoveryTime(long asyncLockRecoveryTime) {
+    this.asyncLockRecoveryTime = asyncLockRecoveryTime;
+  }
+
+  /**
+   * Get start time of the sub tree operation
+   */
+  public long getStartTime() {
+    return startTime;
+  }
+
+  /**
+   * Set start time of the subtree operation
+   * @param startTime start time
+   */
+  public void setStartTime(long startTime) {
+    this.startTime = startTime;
+  }
+
+  /**
+   * Get the user name that started the operation
+   */
+  public String getUser() {
+    return user;
+  }
+
+  /**
+   * Set the user name
+   * @param user
+   */
+  public void setUser(String user) {
+    this.user = user;
+  }
+
+  /**
+   * Get inode ID of the subtree root
+   */
+  public long getInodeID() {
+    return inodeID;
+  }
+
+  /**
+   * Set inode ID of the subtree root
+   * @param inodeID of subtree root
+   */
+  public void setInodeID(long inodeID) {
+    this.inodeID = inodeID;
+  }
 
   @Override
   public int compareTo(SubTreeOperation t) {
@@ -136,6 +213,13 @@ public class SubTreeOperation implements Comparable<SubTreeOperation> {
 
   @Override
   public String toString() {
-    return this.path;
+    return "Path: " + this.path + ", INodeID: "+ inodeID+", NN ID: " + nameNodeId
+            + ", Operation: " + opType + ", User: " + user +
+            ", Start Time:" + (new java.util.Date(startTime)).toString() +
+            (
+                    asyncLockRecoveryTime > 0 ?
+                    ", Recovery Start Time " + (new java.util.Date(asyncLockRecoveryTime)).toString()
+                    : ""
+            );
   }
 }

--- a/src/main/java/io/hops/transaction/handler/TransactionalRequestHandler.java
+++ b/src/main/java/io/hops/transaction/handler/TransactionalRequestHandler.java
@@ -153,7 +153,8 @@ public abstract class TransactionalRequestHandler extends RequestHandler {
                   "RetryCount: " + (tryCount-1) + ", " +
                   "TX Stats -- Setup: " + setupTime + "ms, AcquireLocks: " + acquireLockTime + "ms, " +
                   "InMemoryProcessing: " + inMemoryProcessingTime + "ms, " +
-                  "CommitTime: " + commitTime + "ms. " + t, t);
+                  "CommitTime: " + commitTime + "ms. Locks: "+
+                  getINodeLockInfo(locksAcquirer.getLocks())+". " + t, t);
         }
         if (!(t instanceof TransientStorageException) ||  tryCount > RETRY_COUNT) {
           for(Throwable oldExceptions : exceptions) {
@@ -208,7 +209,7 @@ public abstract class TransactionalRequestHandler extends RequestHandler {
       if(locks != null) {
         Lock ilock = locks.getLock(Lock.Type.INode);
         if (ilock != null) {
-          inodeLockMsg = ilock.toString();
+        inodeLockMsg = ilock.toString();
         }
       }
     }catch (TransactionLocks.LockNotAddedException e){


### PR DESCRIPTION
[HOPS-1343] Recover inode if reset subtree lock fails
[HOPS-1344] Add lock and path information for failed operation
[HOPS-1345] Add more information in on_going_subtree_ops table

## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-1343
https://hopshadoop.atlassian.net/browse/HOPS-1344
https://hopshadoop.atlassian.net/browse/HOPS-1345
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)


* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: