### PR TITLE
[HOPS-1348] alter xattr table - decrease size of xattr value

### DIFF
--- a/src/main/java/io/hops/metadata/hdfs/entity/StoredXAttr.java
+++ b/src/main/java/io/hops/metadata/hdfs/entity/StoredXAttr.java
@@ -26,7 +26,7 @@ public final class StoredXAttr {
   
   public static final int MAX_NUM_XATTRS_PER_INODE = 255;
   public static final int MAX_XATTR_NAME_SIZE = 255;
-  public static final int MAX_XATTR_VALUE_SIZE = 13730;
+  public static final int MAX_XATTR_VALUE_SIZE = 13500;
   
   public enum Finder implements FinderType<StoredXAttr> {
     ByPrimaryKey,


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [ ] All commits have been squashed down to a single commit
- [ ] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/projects/HOPS/issues/HOPS-1348

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature change

* **What is the new behavior (if this is a feature change)?**
feature change - XAttr

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It changes the db. If anyone used XAttr and added values of max size - this would be a big breaking change.

* **Other information**:
https://github.com/hopshadoop/hops-metadata-dal-impl-ndb/pull/206
https://github.com/hopshadoop/hops/pull/687

