### PR TITLE
[HOPS-1365] fix getBlocks to be faster and not kill the DB

### DIFF
--- a/src/main/java/io/hops/metadata/hdfs/dal/ReplicaDataAccess.java
+++ b/src/main/java/io/hops/metadata/hdfs/dal/ReplicaDataAccess.java
@@ -36,7 +36,7 @@ public interface ReplicaDataAccess<T> extends EntityDataAccess {
       storageId, int bucketId) throws StorageException;
   
   boolean hasBlocksWithIdGreaterThan(int storageId, long from) throws StorageException;
-    
+  
   int countAllReplicasForStorageId(int sid) throws StorageException;
   
   void prepare(Collection<T> removed, Collection<T> newed,
@@ -44,4 +44,6 @@ public interface ReplicaDataAccess<T> extends EntityDataAccess {
   
   Map<Long,Long> findBlockAndInodeIdsByStorageIdAndBucketIds (int sId,
       List<Integer> mismatchedBuckets) throws StorageException;
+  
+  long findBlockIdAtIndex(int storageId, long index, int maxFetchingSize) throws StorageException;
 }


### PR DESCRIPTION
## Make sure there is no duplicate PR for this issue

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added and passed (for bug fixes / features)
- [x] HOPS JIRA issue has been opened for this PR
- [x] All commits have been squashed down to a single commit
- [x] The commit message has the following format: [HOPS-XXX] message

* **Post a link to the associated JIRA issue**
https://hopshadoop.atlassian.net/browse/HOPS-1365

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix

* **What is the new behavior (if this is a feature change)?**


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

* **Other information**: